### PR TITLE
add `sudo` to `pip install` in cli-instructions.md

### DIFF
--- a/assays/cli-instructions.md
+++ b/assays/cli-instructions.md
@@ -5,7 +5,7 @@ To upload assay data to the CIDC, you will use the CIDC Command-Line Interface (
 ## Installation
 To install the CIDC CLI, run the following command:
 ```bash
-pip3 install cidc-cli
+sudo pip3 install cidc-cli
 ```
 ## Help
 To display a help message outlining the available commands for the CLI, run:


### PR DESCRIPTION
because without it (at least on ubuntu) pip by default will install into users local site-packages and won't create `cidc` command, which makes next steps in the instructions impossible to do.

Maybe there's a better way than sudo?